### PR TITLE
Fix Get-ContainerIsRunning: Using Containername instead of Fixed Value

### DIFF
--- a/PowerShell/Get-ContainerIsRunning.ps1
+++ b/PowerShell/Get-ContainerIsRunning.ps1
@@ -5,7 +5,7 @@ function Get-ContainerIsRunning {
     )
 
     try {
-    $StatusJson = docker inspect bc
+    $StatusJson = docker inspect $ContainerName
     $StatusJson = [String]::Join([Environment]::NewLine, $StatusJson)
     $Status = ConvertFrom-Json $StatusJson
     }


### PR DESCRIPTION
Hi James,

quick fix for your great idea to put this into a vs code extension.

Kind Regard,

Christian