### PR TITLE
Docker container name should be uppercase

### DIFF
--- a/PowerShell/Get-ServerFromLaunchJson.ps1
+++ b/PowerShell/Get-ServerFromLaunchJson.ps1
@@ -6,7 +6,7 @@ function Get-ServerFromLaunchJson {
     
     $Server = Get-ValueFromLaunchJson -KeyName server -ConfigName $ConfigName
     $Server = $Server.Substring($Server.IndexOf('://') + 3)
-    $Server
+    $Server.ToUpper()
 }
 
 Export-ModuleMember -Function Get-ServerFromLaunchJson


### PR DESCRIPTION
The container is not found if the server address is in lowercase in the launch.json file. Container names are always uppercase.