### PR TITLE
filename sanitized

### DIFF
--- a/PowerShell/Merge-ALTestRunnerResults.ps1
+++ b/PowerShell/Merge-ALTestRunnerResults.ps1
@@ -1,8 +1,8 @@
 ﻿function Merge-ALTestRunnerTestResults {
     Param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$ResultsFile,
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [string]$ToPath = (Split-Path (Get-ALTestRunnerConfigPath) -Parent)  
     )
 
@@ -12,8 +12,8 @@
 
     [xml]$FromResults = Get-Content $ResultsFile -Raw
 
-    foreach ($FromCodeunit in $FromResults.assemblies.assembly) {
-        $ToResultFile = Join-Path $ToPath ($FromCodeunit.Attributes.GetNamedItem('name').Value + ".xml")
+    foreach ($FromCodeunit in $FromResults.assemblies.assembly) {        
+        $ToResultFile = Join-Path $ToPath (($FromCodeunit.Attributes.GetNamedItem('name').Value + ".xml").Split([IO.Path]::GetInvalidFileNameChars()) -join '')
         if (Test-Path $ToResultFile) {
             [Xml]$ToCodeunit = Get-Content $ToResultFile
         

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
 	},
 	"dependencies": {
 		"@types/xml2js": "^0.4.5",
+		"sanitize-filename": "^1.6.3",
 		"xml2js": "^0.4.22"
-	}	
+	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ let timeout: NodeJS.Timer | undefined = undefined;
 let isTestCodeunit: boolean;
 
 export function activate(context: vscode.ExtensionContext) {
-	console.log('jamespearson.al-test-runner extension is activated');	
+	console.log('jamespearson.al-test-runner extension is activated');
 
 	let command = vscode.commands.registerCommand('altestrunner.runAllTests', async (extensionId?: string, extensionName?: string) => {
 		await readyToRunTests().then(ready => {
@@ -64,7 +64,7 @@ export function activate(context: vscode.ExtensionContext) {
 					extensionName = getAppJsonKey('name');
 				}
 
-				invokeTestRunner('Invoke-ALTestRunner -Tests Codeunit -ExtensionId ' + extensionId  + ' -ExtensionName "' + extensionName + '" -FileName "' + filename + '"');
+				invokeTestRunner('Invoke-ALTestRunner -Tests Codeunit -ExtensionId ' + extensionId + ' -ExtensionName "' + extensionName + '" -FileName "' + filename + '"');
 			}
 		});
 	});
@@ -87,7 +87,7 @@ export function activate(context: vscode.ExtensionContext) {
 					extensionName = getAppJsonKey('name');
 				}
 
-				invokeTestRunner('Invoke-ALTestRunner -Tests Test -ExtensionId ' + extensionId  + ' -ExtensionName "' + extensionName + '" -FileName "' + filename + '" -SelectionStart ' + selectionStart);
+				invokeTestRunner('Invoke-ALTestRunner -Tests Test -ExtensionId ' + extensionId + ' -ExtensionName "' + extensionName + '" -FileName "' + filename + '" -SelectionStart ' + selectionStart);
 			}
 		});
 	});
@@ -119,7 +119,7 @@ export function activate(context: vscode.ExtensionContext) {
 			triggerUpdateDecorations();
 		}
 	}, null, context.subscriptions);
-	
+
 	vscode.workspace.onDidChangeTextDocument(event => {
 		if (activeEditor && event.document === activeEditor.document) {
 			triggerUpdateDecorations();
@@ -141,6 +141,8 @@ function updateDecorations() {
 	let failingTests: vscode.DecorationOptions[] = [];
 	let untestedTests: vscode.DecorationOptions[] = [];
 
+	var sanitize = require("sanitize-filename");
+
 	//call with empty arrays to clear all the decorations
 	setDecorations(passingTests, failingTests, untestedTests);
 
@@ -151,7 +153,7 @@ function updateDecorations() {
 
 	let testMethodRanges: types.ALTestMethodRange[] = getTestMethodRangesFromDocument(activeEditor!.document);
 
-	let resultFileName = getALTestRunnerPath() + '\\Results\\' + getDocumentIdAndName(activeEditor!.document) + '.xml';
+	let resultFileName = getALTestRunnerPath() + '\\Results\\' + sanitize(getDocumentIdAndName(activeEditor!.document)) + '.xml';
 	if (!(existsSync(resultFileName))) {
 		setDecorations(passingTests, failingTests, getUntestedTestDecorations(testMethodRanges));
 		return;
@@ -249,7 +251,7 @@ export function getTestMethodRangesFromDocument(document: vscode.TextDocument): 
 
 			//if the line has a double slash before the method name then it has been commented out, don't include in the results
 			const textLine = document.lineAt(startPos.line);
-			if (textLine.text.substr(textLine.firstNonWhitespaceCharacterIndex,2) === '//') {
+			if (textLine.text.substr(textLine.firstNonWhitespaceCharacterIndex, 2) === '//') {
 				procedureCommentedOut = true;
 			}
 
@@ -375,7 +377,7 @@ export function getDocumentIdAndName(document: vscode.TextDocument): string {
 
 function outputTestResults() {
 	let resultFileName = getALTestRunnerPath() + '\\last.xml';
-	if (existsSync(resultFileName)) {			
+	if (existsSync(resultFileName)) {
 		outputChannel.clear();
 		outputChannel.show(true);
 
@@ -397,7 +399,7 @@ function outputTestResults() {
 				}
 				else {
 					outputChannel.appendLine('✅ ' + assembly.$.name + '\t' + assemblyTime.toFixed(2) + 's');
-				}					
+				}
 				assembly.collection[0].test.forEach(test => {
 					const testTime = parseFloat(test.$.time);
 					if (test.$.result === 'Pass') {
@@ -409,7 +411,7 @@ function outputTestResults() {
 					}
 				});
 			});
-			
+
 			if (noOfFailures === 0) {
 				outputChannel.appendLine('✅ ' + noOfTests + ' test(s) ran in ' + totalTime.toFixed(2) + 's');
 			}
@@ -417,7 +419,7 @@ function outputTestResults() {
 				outputChannel.appendLine('❌ ' + noOfTests + ' test(s) ran in ' + totalTime.toFixed(2) + 's - ' + noOfFailures + ' test(s) failed');
 			}
 		});
-		
+
 		unlinkSync(resultFileName);
 	}
 }
@@ -437,12 +439,12 @@ export function getLaunchJson() {
 
 function getAppJsonKey(keyName: string) {
 	const appJsonPath = getWorkspaceFolder() + '\\app.json';
-	const data = readFileSync(appJsonPath, { encoding: 'utf-8'});
-	const appJson =  JSON.parse(data);
+	const data = readFileSync(appJsonPath, { encoding: 'utf-8' });
+	const appJson = JSON.parse(data);
 	return appJson[keyName];
 }
 
-function getALTestRunnerPath(): string {	
+function getALTestRunnerPath(): string {
 	const alTestRunnerPath = getWorkspaceFolder() + '\\.altestrunner';
 	watchALTestRunnerPath(alTestRunnerPath);
 	return alTestRunnerPath;
@@ -463,14 +465,14 @@ function watchALTestRunnerPath(path: string) {
 	}
 }
 
-function getWorkspaceFolder() {	
+function getWorkspaceFolder() {
 	const wsFolders = vscode.workspace.workspaceFolders!;
 	if (wsFolders !== undefined) {
 		if (wsFolders.length === 1) {
 			return wsFolders.shift()!.uri.fsPath;
 		}
 	}
-	
+
 	if (activeEditor === undefined || activeEditor === null) {
 		throw new Error('Please open a file in the project you want to run the tests for.');
 	}
@@ -479,7 +481,7 @@ function getWorkspaceFolder() {
 		if (workspace === undefined) {
 			throw new Error('Please open a file in the project you want to run the tests for.');
 		}
-		return workspace!.uri.fsPath;			
+		return workspace!.uri.fsPath;
 	}
 }
 
@@ -525,7 +527,7 @@ function createALTestRunnerConfig() {
 
 function createALTestRunnerDir() {
 	if (getALTestRunnerPath() === '') {
-		return;	
+		return;
 	}
 
 	if (!(existsSync(getALTestRunnerPath()))) {


### PR DESCRIPTION
Hi,

I started using your tool today and I'm greatly enjoying it. 
I found an issue with how you handle the result file names: Since codeunit names in AL don't follow the naming restriction of windows it can occur that the result name cannot be renamed and therefore not be used for decorators.
I wrote a quick fix for both issues in PS and and extension itself. Hope you can include this in the extension

Cheers Leon