### PR TITLE
Simple extension API for external integrations

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,10 @@ const outputChannel = vscode.window.createOutputChannel(getTerminalName());
 let timeout: NodeJS.Timer | undefined = undefined;
 let isTestCodeunit: boolean;
 
+const alTestRunnerAPI = new class {
+	getWorkspaceFolder: Function | undefined;
+};
+
 export function activate(context: vscode.ExtensionContext) {
 	console.log('jamespearson.al-test-runner extension is activated');
 
@@ -161,6 +165,8 @@ export function activate(context: vscode.ExtensionContext) {
 			triggerUpdateDecorations();
 		}
 	}, null, context.subscriptions);
+
+	return alTestRunnerAPI;
 }
 
 async function invokeTestRunner(command: string) {
@@ -601,6 +607,13 @@ function watchALTestRunnerPath(path: string) {
 }
 
 function getWorkspaceFolder() {
+	if (alTestRunnerAPI.getWorkspaceFolder) {
+		let override = alTestRunnerAPI.getWorkspaceFolder.call(null);
+		if (override && override.length > 0) {
+			return override;
+		}
+	}
+
 	const wsFolders = vscode.workspace.workspaceFolders!;
 	if (wsFolders !== undefined) {
 		if (wsFolders.length === 1) {


### PR DESCRIPTION
Hi James,

I've been working on integrating your extension with AL Object Designer and I ran into some issues that required a bit more touch to overcome them.


To solve my pain points, I'd like to introduce a simple API that AL Test Runner provides to other extensions.

```js
const alTestRunnerAPI = new class {
	getWorkspaceFolder: Function | undefined;
	onOutputTestResults: Function | undefined;
};
```

1. Currently, an active editor (opened, in focus) is required to run the tests.

This is an issue as I want to execute "headless" tests, originating from a WebView window that is not related to any of the workspace folders.

`getWorkspaceFolder` API function provides an optional override where I can give in the appropriate path without opening an editor.

[Implemented usage](https://github.com/martonsagi/al-object-designer/blob/e6a8c0b88222032453d80d7078488592d7c73838/extension-al-object-designer/src/Commands/ALTestRunnerCommand.ts#L51)

2. Exact finishing of a test run cannot be determined from code

This becomes an issue for me because of the solution for pain point 1. :)
So, overriding `getWorkspaceFolder` has a permanent effect that should be removed when the current test run is finished. 
To solve this, I introduced `onOutputTestResults` event that one can subscribe to externally. This event runs multiple times but I was able to determine the real finishing moment with some quirks.

[Implemented usage](https://github.com/martonsagi/al-object-designer/blob/e6a8c0b88222032453d80d7078488592d7c73838/extension-al-object-designer/src/Commands/ALTestRunnerCommand.ts#L24)

-------
All in all, it would be a big help if you could accept these changes provided it won't break anything else. 
(Sorry for additional formatting changes, I always hit Ctrl+Shift+F to reformat JS/TS files.)

Thanks,
Marton