### PR TITLE
Adding multitenant support

### DIFF
--- a/PowerShell/Get-TenantFromLaunchJson.ps1
+++ b/PowerShell/Get-TenantFromLaunchJson.ps1
@@ -1,0 +1,12 @@
+function Get-TenantFromLaunchJson {
+    param (
+        [Parameter(Mandatory=$false)]
+        $ConfigName = (Get-ValueFromALTestRunnerConfig -KeyName 'launchConfigName')
+    )
+    
+    $Tenant = Get-ValueFromLaunchJson -KeyName tenant -ConfigName $ConfigName
+
+    return $Tenant
+}
+
+Export-ModuleMember -Function Get-TenantFromLaunchJson

--- a/PowerShell/Invoke-ALTestRunner.ps1
+++ b/PowerShell/Invoke-ALTestRunner.ps1
@@ -49,7 +49,12 @@ function Invoke-ALTestRunner {
         TestSuiteName = $TestSuiteName
         ExtensionName = $ExtensionName
     }
-    
+
+    $Tenant = Get-TenantFromLaunchJson
+    if ($Tenant) {
+        $Params.Add('Tenant', $Tenant)
+    }
+
     if ($FileName -ne '') {
         if (Get-FileIsTestCodeunit -FileName $FileName) {
             $Params.Add('TestCodeunit', (Get-ObjectIdFromFile $FileName))

--- a/PowerShell/Invoke-RunTests.ps1
+++ b/PowerShell/Invoke-RunTests.ps1
@@ -1,7 +1,9 @@
 function Invoke-RunTests {
     Param(
         [Parameter(Mandatory=$true)]
-        $ContainerName,
+        $ContainerName,        
+        [Parameter(Mandatory=$false)]
+        $Tenant,
         [Parameter(Mandatory=$true)]
         $CompanyName,
         [Parameter(Mandatory=$false)]
@@ -38,6 +40,11 @@ function Invoke-RunTests {
         $Params.Add('credential', $Credential)
     }
     
+    if ($Tenant) {
+        $Params.Add('tenant', $Tenant)
+        $Message += ", tenant $Tenant"
+    }
+
     if ($TestCodeunit -ne '') {
         $Params.Add('testCodeunit', $TestCodeunit)
         $Message += ", codeunit $TestCodeunit"


### PR DESCRIPTION
Hi James, 

When testing your extension with multi-tenant container on shared remote docker host I found out that it is missing multi-tenant support. 

I have amended the scripts to take _tenant_ parameter from the launch json and use it when invoking the tests.

If you accept this PR, it will make my life easier.

Thanks,
  Igor


