### PR TITLE
FIX: Added getCurrentWorkspaceConfig (#30)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -214,7 +214,7 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 async function invokeTestRunner(command: string) {
-	const config = vscode.workspace.getConfiguration('al-test-runner');
+	const config = getCurrentWorkspaceConfig();
 
 	switch (config.publishBeforeTest) {
 		case 'Publish':
@@ -253,7 +253,7 @@ function initDebugTest(filename: string) {
 	terminal.sendText('Invoke-TestRunnerService -FileName "' + filename + '" -Init');
 	
 	const sleep = require("system-sleep");
-	const config = vscode.workspace.getConfiguration('al-test-runner');
+	const config = getCurrentWorkspaceConfig();
 	sleep(config.testRunnerInitialisationTime);
 }
 
@@ -291,7 +291,7 @@ function invokeCommand(command: string) {
 }
 
 function updateDecorations() {
-	const config = vscode.workspace.getConfiguration('al-test-runner');
+	const config = getCurrentWorkspaceConfig();
 
 	let passingTests: vscode.DecorationOptions[] = [];
 	let failingTests: vscode.DecorationOptions[] = [];
@@ -565,7 +565,7 @@ export function getLineNumberOfMethodDeclaration(method: string, document: vscod
 
 export async function getFilePathByCodeunitId(codeunitId: number, method?: string): Promise<string> {
 	return new Promise(async (resolve, reject) => {
-		const config = vscode.workspace.getConfiguration('al-test-runner');
+		const config = getCurrentWorkspaceConfig();
 		const globPattern = config.testCodeunitGlobPattern;
 		if ((globPattern === '') || (globPattern === undefined)) {
 			resolve('');
@@ -733,6 +733,10 @@ function getWorkspaceFolder() {
 		}
 		return workspace!.uri.fsPath;
 	}
+}
+
+function getCurrentWorkspaceConfig() {
+	return vscode.workspace.getConfiguration('al-test-runner', vscode.Uri.file(getWorkspaceFolder()));
 }
 
 function getALTestRunnerConfigPath(): string {


### PR DESCRIPTION
I added the scope parameter to all getConfiguration calls - except from the global config object defined in line 12, since it seemed like it was supposed to be set only once.
This makes sure the activeEditor's workspaceFolder is used instead of the first workspaceFolder when settings are read.
Fixes issue #30 