### PR TITLE
Support AAD Authentication by using a Refresh Token

### DIFF
--- a/PowerShell/Invoke-RunTests.ps1
+++ b/PowerShell/Invoke-RunTests.ps1
@@ -90,7 +90,11 @@ function Invoke-RunTests {
     while (!$BreakTestLoop) {
         try {
             Write-Host $Message -ForegroundColor Green
-
+            $refreshToken = Get-ValueFromALTestRunnerConfig -KeyName 'refreshToken'
+            if ($null -ne $refreshToken) {
+                $authContext = New-BcAuthContext -refreshToken $refreshToken
+                $Params.Add('bcAuthContext', $authContext)
+            }
             Invoke-CommandOnDockerHost { Param($Params) Run-TestsInBCContainer @Params -detailed -Verbose } -Parameters $Params
             
             if (Get-DockerHostIsRemote) {


### PR DESCRIPTION
To use AAD Authentication New-BcAuthContext is being used, when a Refresh Token is supplied. The token can be acquired by: $authContext = New-BcAuthContext -scopes '[your AAD App Id]/user_impersonation offline_access' -tenantID '[your Tenant Id]' -includeDeviceLogin $authContext.RefreshToken