### PR TITLE
One or more errors occurred. (One or more errors occurred. (Invalid JSON. The value 'x..y' is not a valid number.))

### DIFF
--- a/PowerShell/Invoke-TestRunnerService.ps1
+++ b/PowerShell/Invoke-TestRunnerService.ps1
@@ -14,7 +14,7 @@ function Invoke-TestRunnerService {
         $ServiceUrl = Get-ServiceUrl -Method 'RunTestsFromFilter'
         $CodeunitIDFilter = Get-FilterFromIDRanges
         $TestName = 'InitTestRunnerService'
-        $Body = "{`"codeunitIdFilter`": $CodeunitIDFilter, `"testName`": `"$TestName`"}"
+        $Body = "{`"codeunitIdFilter`": `"$CodeunitIDFilter`", `"testName`": `"$TestName`"}"
         Write-Host "Initialising test runner"
     }
     elseif ($FileName -ne '') {


### PR DESCRIPTION
Fixes #89