### PR TITLE
Test run doesnt start from workspace (overrrides config.json)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -93,7 +93,8 @@ export function launchConfigIsValid(alTestRunnerConfig?: types.ALTestRunnerConfi
 }
 
 export function getDebugConfigurationsFromLaunchJson(type: string) {
-	const configuration = vscode.workspace.getConfiguration('launch', vscode.workspace.workspaceFolders![0]);
+	const testWorkspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(getALTestRunnerConfigPath()));
+	const configuration = vscode.workspace.getConfiguration('launch', testWorkspaceFolder);
 	const debugConfigurations = configuration.configurations as Array<vscode.DebugConfiguration>;
 	return debugConfigurations.filter(element => { return element.request === type; }).slice();
 }


### PR DESCRIPTION
Fixes #102

Take debug configuration from test folder, not first folder in the workspace