### PR TITLE
Remove BOM from app.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.10.0
+- Option to calculate and download performance trace when running tests
+  -  Show performance item in status bar
+  - Download and install pre-BC22 Test Runner Service when applicable
+- Fix issue suggesting testRunnerService url
+- Rediscover test methods when renaming test codeunit
+- Fix recognition of test codeunit files
+
 ## 0.9.3
 - Fix [issue 102](https://github.com/jimmymcp/al-test-runner/issues/102), debug configuration not found when first workspace is .AL-GO
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.9.1
+- Attempt to automatically discover the workspace which contains the tests (looking for terms in the "Test Workspace Folder Identifiers" settings)
+- Fix error seen when initialising debugger
+
 # 0.9.0
 - Fixed various compatibility issues with PowerShell 7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.9.2
+- Fix [issue 100](https://github.com/jimmymcp/al-test-runner/issues/100), debugging tests in codeunit which starts with a summary block
+- Tidying up the cases of some of the ts file names
+
 # 0.9.1
 - Attempt to automatically discover the workspace which contains the tests (looking for terms in the "Test Workspace Folder Identifiers" settings)
 - Fix error seen when initialising debugger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.9.3
+- Fix [issue 102](https://github.com/jimmymcp/al-test-runner/issues/102), debug configuration not found when first workspace is .AL-GO
+
 ## 0.9.2
 - Fix [issue 100](https://github.com/jimmymcp/al-test-runner/issues/100), debugging tests in codeunit which starts with a summary block
 - Tidying up the cases of some of the ts file names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.10.1
+- Do not require restart of tests after selecting launch configuration to use, [issue 113](https://github.com/jimmymcp/al-test-runner/issues/113)
+- Fix issue where test codeunits not recognised when using namespaces, [issue 115](https://github.com/jimmymcp/al-test-runner/issues/115)
+- Fix issue with long method names in HandlerFunctions, [issue 116](https://github.com/jimmymcp/al-test-runner/issues/116)
+
+
 ## 0.10.0
 - Option to calculate and download performance trace when running tests
   -  Show performance item in status bar

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"files": [
 		"PowerShell/"
 	],
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"engines": {
 		"vscode": ">=1.63.0"
 	},

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"files": [
 		"PowerShell/"
 	],
-	"version": "0.9.3",
+	"version": "0.10.0",
 	"engines": {
 		"vscode": ">=1.63.0"
 	},

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"files": [
 		"PowerShell/"
 	],
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"engines": {
 		"vscode": ">=1.63.0"
 	},

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"files": [
 		"PowerShell/"
 	],
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"engines": {
 		"vscode": ">=1.63.0"
 	},

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"files": [
 		"PowerShell/"
 	],
-	"version": "0.9.2",
+	"version": "0.9.3",
 	"engines": {
 		"vscode": ">=1.63.0"
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -435,7 +435,9 @@ export function getAppJsonKey(keyName: string) {
 	sendDebugEvent('getAppJsonKey-start', { keyName: keyName });
 	const appJsonPath = getTestFolderPath() + '\\app.json';
 	const data = readFileSync(appJsonPath, { encoding: 'utf-8' });
-	const appJson = JSON.parse(data);
+	const appJson = JSON.parse(data.charCodeAt(0) === 0xfeff
+		? data.slice(1) // Remove BOM
+		: data);
 
 	sendDebugEvent('getAppJsonKey-end', { keyName: keyName, keyValue: appJson[keyName] });
 	return appJson[keyName];


### PR DESCRIPTION
In some of our apps we seem to have the app.json file saved as UTF8-BOM.
Don't ask me why they are saved like that, it seems to be unintentionally changed by some user in some cases. Maybe some extension that are doing something, I don't know...

That BOM does not have any impact when developing in AL nowadays, except when using AL Test Runner. 
And the issue is quite annoying and you have no idea on what is being wrong, since the test runner is just hanging...  (see https://github.com/jimmymcp/al-test-runner/issues/48 for more details)

This little change removes any BOM from the app.json data before parsing the content.

I hope you can consider merging this. 🙂

Cheers,
Johannes