### PR TITLE
Enable Code Coverage enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -303,10 +303,14 @@
 						"description": "A regex pattern which defines file paths to exclude from the code coverage summary e.g. use it to exclude test objects"
 					},
 					"al-test-runner.enableCodeCoverage": {
-						"type": "boolean",
+						"enum": [
+							"No",
+							"When running all tests",
+							"Always"
+						],
 						"scope": "resource",
 						"description": "Outputs code coverage statistics with test results and decorates covered lines with the Toggle Code Coverage command. See also the Code Coverage Path extension setting and key in the AL Test Runner config.json file.",
-						"default": true
+						"default": "When running all tests"
 					},
 					"al-test-runner.enablePerformanceProfiler": {
 						"type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,7 +122,7 @@ export function activate(context: vscode.ExtensionContext) {
 	discoverTests();
 }
 
-export async function invokeTestRunner(command: string): Promise<types.ALTestAssembly[]> {
+export async function invokeTestRunner(command: string, options: types.invokeTestRunnerOptions): Promise<types.ALTestAssembly[]> {
 	return new Promise(async (resolve) => {
 		sendDebugEvent('invokeTestRunner-start');
 		const config = getCurrentWorkspaceConfig();
@@ -147,7 +147,7 @@ export async function invokeTestRunner(command: string): Promise<types.ALTestAss
 			return;
 		}
 
-		if (config.enableCodeCoverage) {
+		if (options.enableCodeCoverage) {
 			command += ' -GetCodeCoverage';
 		}
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -74,13 +74,7 @@ function sendTestRunEvent(eventName: string, request: vscode.TestRunRequest) {
     let codeCoverageEnabled, publishBeforeTest, enablePublishingFromPowerShell: string;
     const config = getCurrentWorkspaceConfig();
 
-    if (config.enableCodeCoverage) {
-        codeCoverageEnabled = 'true';
-    }
-    else {
-        codeCoverageEnabled = 'false';
-    }
-
+    codeCoverageEnabled = config.enableCodeCoverage;
     publishBeforeTest = config.publishBeforeTest;
 
     if (config.enablePublishingFromPowerShell) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,3 +140,13 @@ export enum launchConfigValidity {
 	Invalid,
 	NeverValid
 }
+
+export enum enableCodeCoverage {
+	No = 'No',
+	'When running all tests' = 'When running all tests',
+	Always = 'Always'
+}
+
+export type invokeTestRunnerOptions = {
+	enableCodeCoverage: boolean
+}


### PR DESCRIPTION
Change the enabel code coverage option to an enum to allow the option to only enable code coverage when running all the tests.