### PR TITLE
Do not attempt to read code coverage when it has not been captured

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: package with vsce
         run: |
-          npm install -g vsce
+          npm install -g @vscode/vsce
           vsce package
 
       - name: run pester tests

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,3 +9,4 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 PowerShell/Tests/**
+.github/**

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
 		"url": "https://github.com/jimmymcp/al-test-runner"
 	},
 	"icon": "semicolon128.jpg",
-	"files": [
-		"PowerShell/"
-	],
 	"version": "10.13.6",
 	"engines": {
 		"vscode": ">=1.88.0"


### PR DESCRIPTION
Fixes possibility that code coverage has not been captured (because it is not used or only used when running all tests) but the test run attempts to read and assign the coverage at the end of the test run anyway.

Causes the run to fail to finish and display the test results properly.