### PR TITLE
Specify acronyms that should not be split when exporting tests to CSV

### DIFF
--- a/package.json
+++ b/package.json
@@ -386,6 +386,19 @@
 						"type": "string",
 						"scope": "resource",
 						"description": "Path to a BC compiler folder created with New-BCCompilerFolder. Used for running tests via a URL."
+					},
+					"al-test-runner.testNameAcronyms": {
+						"type": "array",
+						"scope": "resource",
+						"description": "Defines acronyms that should not be separated by spaces when exporting test names to CSV",
+						"default": [
+							"VAT",
+							"LCY",
+							"FCY",
+							"OK",
+							"ID",
+							"NFP"
+						]
 					}
 				}
 			}

--- a/src/devOpsTestSteps.ts
+++ b/src/devOpsTestSteps.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { DevOpsTestStep } from './types';
+import { getCurrentWorkspaceConfig } from './config';
 
 export async function exportTestItemsToCsv(testItem: vscode.TestItem) {
     const testSteps = await getDevOpsTestStepsForTestItems(testItem);
@@ -75,8 +76,22 @@ function capitaliseFirstCharacter(text: string): string {
     return text.charAt(0).toUpperCase() + text.slice(1);
 }
 
-function pasalCaseToSentenceCase(pascalCase: string): string {
-    return pascalCase.replace(/([A-Z])/g, ' $1').trim();
+export function pasalCaseToSentenceCase(pascalCase: string, acronymsToKeep?: string[]): string {
+    let sentenceCase = pascalCase.replace(/([A-Z])/g, ' $1').trim();
+
+    if (!acronymsToKeep) {
+        acronymsToKeep = getCurrentWorkspaceConfig().testNameAcronyms;
+    }
+
+    if (acronymsToKeep) {
+        acronymsToKeep.forEach(acronym => {
+            if (pascalCase.includes(acronym)) {
+                let splitAcronym = acronym.replace(/([A-Z])/g, ' $1').trim();
+                sentenceCase = sentenceCase.replace(splitAcronym, acronym);
+            }
+        });
+    }
+    return sentenceCase;
 }
 
 export async function getCommentLinesForTestItem(testItem: vscode.TestItem): Promise<string[]> {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -10,7 +10,7 @@ import { getMaxLengthOfPropertyFromArray } from '../../output';
 import { join } from 'path';
 import { getGitFolderPathForFolder } from '../../git';
 import { getParentFolderPathForFolder } from '../../file';
-import { getCommentLinesForTestItem, getDevOpsTestStepsForTestItems } from '../../devOpsTestSteps';
+import { getCommentLinesForTestItem, getDevOpsTestStepsForTestItems, pasalCaseToSentenceCase } from '../../devOpsTestSteps';
 import { DevOpsTestStep } from '../../types';
 
 const tempDir: string = os.tmpdir() + '\\ALTR';
@@ -733,5 +733,23 @@ suite('Extension Test Suite', () => {
         const testSteps: DevOpsTestStep[] = await getDevOpsTestStepsForTestItems(testItem);
 
         assert.strictEqual(testSteps.length, 4);
+    });
+
+    test('pascalSentenceToSentenceCase converts pascalCase to sentence case', () => {
+        assert.strictEqual(pasalCaseToSentenceCase('thisIsASentence'), 'this Is A Sentence');
+    });
+
+    test('pasalCaseToSentenceCase does not preserve acronyms when none specified', () => {
+        assert.strictEqual(pasalCaseToSentenceCase('calculateVATForDocument'), 'calculate V A T For Document');
+    });
+
+    test('pascalSentenceToSentenceCase preserves single acronym', () => {
+        assert.strictEqual(pasalCaseToSentenceCase('calculateVATForDocument', ['VAT']), 'calculate VAT For Document');
+    });
+
+    test('pascalSentenceToSentenceCase preserves multiple acronyms', () => {
+        assert.strictEqual(pasalCaseToSentenceCase('testERPVATSupport', ['ERP', 'VAT']), 'test ERP VAT Support');
+        assert.strictEqual(pasalCaseToSentenceCase('testCurrencyIsEMUOrLCY', ['EMU', 'LCY']), 'test Currency Is EMU Or LCY');
+        assert.strictEqual(pasalCaseToSentenceCase('convertDocumentAmountIncVATFromLCYToFCY', ['FCY', 'LCY', 'VAT']), 'convert Document Amount Inc VAT From LCY To FCY');
     });
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -740,7 +740,8 @@ suite('Extension Test Suite', () => {
     });
 
     test('pasalCaseToSentenceCase does not preserve acronyms when none specified', () => {
-        assert.strictEqual(pasalCaseToSentenceCase('calculateVATForDocument'), 'calculate V A T For Document');
+        //have to pass a value otherwise the default value from package.json will apply
+        assert.strictEqual(pasalCaseToSentenceCase('calculateVATForDocument', ['none']), 'calculate V A T For Document');
     });
 
     test('pascalSentenceToSentenceCase preserves single acronym', () => {


### PR DESCRIPTION
Fixes #162