### PR TITLE
Optionally provide default value to Get-ValueFromLaunchJson

### DIFF
--- a/PowerShell/Get-ValueFromLaunchJson.ps1
+++ b/PowerShell/Get-ValueFromLaunchJson.ps1
@@ -7,7 +7,9 @@ function Get-ValueFromLaunchJson {
         [Parameter(Mandatory=$true)]
         $KeyName,
         [Parameter(Mandatory=$false)]
-        $LaunchConfig
+        $LaunchConfig,
+        [Parameter(Mandatory=$false)]
+        $DefaultValue
     )
 
     if (![String]::IsNullOrEmpty($LaunchConfig)) {
@@ -17,6 +19,10 @@ function Get-ValueFromLaunchJson {
         elseif ($null -ne ($LaunchConfig | ConvertFrom-Json).$KeyName){
             return ($LaunchConfig | ConvertFrom-Json).$KeyName
         } 
+    }
+
+    if ($null -ne $DefaultValue) {
+        return $DefaultValue
     }
 
     if ([String]::IsNullOrEmpty($LaunchJsonPath)) {

--- a/PowerShell/Suggest-ServiceUrl.ps1
+++ b/PowerShell/Suggest-ServiceUrl.ps1
@@ -8,7 +8,7 @@ function Suggest-ServiceUrl {
 
     $ContainerName = Get-ContainerName -LaunchConfig $LaunchConfig
     $ServerInstance = Get-ValueFromLaunchJson -KeyName 'serverInstance' -LaunchConfig $LaunchConfig
-    $LaunchPort = Get-ValueFromLaunchJson -KeyName 'port' -LaunchConfig $LaunchConfig
+    $LaunchPort = Get-ValueFromLaunchJson -KeyName 'port' -LaunchConfig $LaunchConfig -DefaultValue 0
     $Protocol = "http://"
     $CompanyName = Get-ValueFromALTestRunnerConfig -KeyName 'companyName'
 

--- a/PowerShell/Tests/Get-ValueFromLaunchJson.Tests.ps1
+++ b/PowerShell/Tests/Get-ValueFromLaunchJson.Tests.ps1
@@ -59,5 +59,9 @@ Describe Get-LaunchJson {
         It "returns the KeyName that is requested from the config" {
             Get-ValueFromLaunchJson -LaunchConfig '{"name": "testconfig", "server": "serverone"}' -KeyName 'server' | should -be 'serverone'
         }
+
+        It "returns the default value that is passed when the requested value is not present" {
+            Get-ValueFromLaunchJson -LaunchConfig '{"name": "testconfig", "server": "serverone"}' -KeyName 'port' -DefaultValue 8080 | should -be 8080
+        }
     }
 }


### PR DESCRIPTION
Specifically for the port value. If this is provided then we need to test whether it is the https port - then again, it might not be specified at all.