### PR TITLE
Fix error message format

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -55,6 +55,16 @@
 				"clear": false,
 				"close": true
 			}
+		},
+		{
+			"label": "Package VSIX",
+			"type": "shell",
+			"command": "vsce package",
+			"problemMatcher": [],
+			"presentation": {
+				"reveal": "always",
+				"panel": "shared"
+			}
 		}
 	],
 	"inputs": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@types/mocha": "^5.2.6",
 				"@types/node": "^10.17.60",
 				"@types/sinon": "^7.5.2",
-				"@types/vscode": "^1.88.0",
+				"@types/vscode": "^1.93.0",
 				"@vscode/test-electron": "^2.3.9",
 				"glob": "^7.1.7",
 				"mocha": "^10.8.2",
@@ -27,7 +27,7 @@
 				"typescript": "^4.6.3"
 			},
 			"engines": {
-				"vscode": ">=1.88.0"
+				"vscode": ">=1.93.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -150,10 +150,11 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.88.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.88.0.tgz",
-			"integrity": "sha512-rWY+Bs6j/f1lvr8jqZTyp5arRMfovdxolcqGi+//+cPDOh8SBvzXH90e7BiSXct5HJ9HGW6jATchbRTpTJpEkw==",
-			"dev": true
+			"version": "1.106.1",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.106.1.tgz",
+			"integrity": "sha512-R/HV8u2h8CAddSbX8cjpdd7B8/GnE4UjgjpuGuHcbp1xV6yh4OeqU4L1pKjlwujCrSFS0MOpwJAIs/NexMB1fQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/xml2js": {
 			"version": "0.4.9",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -265,6 +265,22 @@ async function readTestResults(uri: vscode.Uri): Promise<types.ALTestAssembly[]>
 		const resultObj = await xmlParser.parseStringPromise(resultXml);
 		const assemblies: types.ALTestAssembly[] = resultObj.assemblies.assembly;
 
+		// Convert xml2js arrays to strings for failure messages and stack traces
+		assemblies.forEach(assembly => {
+			assembly.collection?.forEach(collection => {
+				collection.test?.forEach(test => {
+					if (test.failure && test.failure[0]) {
+						if (Array.isArray(test.failure[0].message)) {
+							test.failure[0].message = test.failure[0].message[0] || '';
+						}
+						if (Array.isArray(test.failure[0]['stack-trace'])) {
+							test.failure[0]['stack-trace'] = test.failure[0]['stack-trace'][0] || '';
+						}
+					}
+				});
+			});
+		});
+
 		resolve(assemblies);
 	});
 }
@@ -340,6 +356,18 @@ function updateDecorations() {
 		const collection = resultObj.assembly.collection;
 		const tests = collection.shift()!.test as Array<types.ALTestResult>;
 
+		// Convert xml2js arrays to strings for failure messages and stack traces
+		tests.forEach(test => {
+			if (test.failure && test.failure[0]) {
+				if (Array.isArray(test.failure[0].message)) {
+					test.failure[0].message = test.failure[0].message[0] || '';
+				}
+				if (Array.isArray(test.failure[0]['stack-trace'])) {
+					test.failure[0]['stack-trace'] = test.failure[0]['stack-trace'][0] || '';
+				}
+			}
+		});
+
 		tests.forEach(test => {
 			const testMethod = testMethodRanges.find(element => element.name === test.$.method);
 			if ((null !== testMethod) && (undefined !== testMethod)) {
@@ -355,12 +383,14 @@ function updateDecorations() {
 						passingTests.push(decoration);
 						break;
 					case 'Fail':
-						const hoverMessage: string = test.failure[0].message + "\n\n" + test.failure[0]["stack-trace"];
+						const message = test.failure[0].message;
+						const stackTrace = test.failure[0]['stack-trace'];
+						const hoverMessage: string = message + "\n\n" + stackTrace;
 						decoration = { range: new vscode.Range(startPos, endPos), hoverMessage: hoverMessage };
 						failingTests.push(decoration);
 
 						if (config.highlightFailingLine) {
-							const failingLineRange = getRangeOfFailingLineFromCallstack(test.failure[0]["stack-trace"][0], test.$.method, activeEditor!.document);
+							const failingLineRange = getRangeOfFailingLineFromCallstack(stackTrace, test.$.method, activeEditor!.document);
 							if (failingLineRange) {
 								const decoration: vscode.DecorationOptions = { range: failingLineRange, hoverMessage: hoverMessage };
 								failingLines.push(decoration);

--- a/src/testController.ts
+++ b/src/testController.ts
@@ -209,7 +209,7 @@ function setResultsForTestItems(results: ALTestAssembly[], request: vscode.TestR
     testItems!.forEach(testItem => {
         if (isErrorResult) {
             // Mark all tests as failed with the error message
-            const errorMessage = results[0].collection[0].test[0].failure[0].message[0];
+            const errorMessage = results[0].collection[0].test[0].failure[0].message;
             if (testItem.parent) {
                 run.failed(testItem, new vscode.TestMessage(errorMessage));
             } else {
@@ -418,7 +418,9 @@ function setResultForTestItem(result: ALTestResult, testItem: vscode.TestItem, r
         run.passed(testItem);
     }
     else {
-        run.failed(testItem, new vscode.TestMessage(`${result.failure[0].message[0]}\n\n${result.failure[0]["stack-trace"][0]}`));
+        const message = result.failure[0].message;
+        const stackTrace = result.failure[0]['stack-trace'];
+        run.failed(testItem, new vscode.TestMessage(`${message}\n\n${stackTrace}`));
     }
 }
 
@@ -602,8 +604,9 @@ async function outputTestResults(assemblies: ALTestAssembly[]): Promise<Boolean>
                     const errorTest = assembly.collection[0].test[0];
                     if (errorTest.failure && errorTest.failure[0]) {
                         outputWriter.write('\t' + errorTest.failure[0].message);
-                        if (errorTest.failure[0]['stack-trace']) {
-                            outputWriter.write('\t' + errorTest.failure[0]['stack-trace']);
+                        const stackTrace = errorTest.failure[0]['stack-trace'];
+                        if (stackTrace) {
+                            outputWriter.write('\t' + stackTrace);
                         }
                     }
                 }


### PR DESCRIPTION
## Developer experience improvements

### 1. Add VSIX packaging task
- Created "Package VSIX" task in `.vscode/tasks.json`
- Build extension packages via **Tasks: Run Task** → **Package VSIX**

### 2. Update package-lock.json
Updated dependencies for consistent builds.

### 3. Simplify failure message handling

**Problem:** xml2js returns arrays (`message: ['text']`) but manually created errors used strings (`message: 'text'`), requiring helper functions to handle both.

**Solution:** Normalize everything to strings immediately after parsing XML. Remove helper functions.

**Changes:**
- Convert xml2js arrays to strings after parsing
- Updated types: `failure.message` and `failure['stack-trace']` are now `string` (not `string | string[]`)
- Direct property access: `test.failure[0].message` instead of `getFailureMessage(test.failure[0])`

**Benefits:** Clearer code, better type safety, less fragile.